### PR TITLE
Windows でビルドできるようにして、CIを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: build
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install
+    - run: npm run build
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install
+    - run: npm run build

--- a/bin/config.js
+++ b/bin/config.js
@@ -38,7 +38,7 @@ const envText =
   Object.keys(config)
     // オブジェクト等は環境変数として出力しない
     .filter((key) => typeof config[key] === "string" || typeof config[key] === "number")
-    .map((key) => `export REACT_APP_${key.toUpperCase()}="${config[key]}"`)
+    .map((key) => `REACT_APP_${key.toUpperCase()}="${config[key]}"`)
     .join("\n") + "\n";
 
 // 全ての設定は src/config.json として出力する

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "typescript": "~3.7.2"
   },
   "scripts": {
-    "start": "node bin/config.js && . ./.env && react-scripts start",
-    "build": "node bin/config.js && . ./.env && react-scripts build",
+    "start": "node bin/config.js && react-scripts start",
+    "build": "node bin/config.js && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
環境変数の取り扱いは Windows と Unix で差があるのですが、`create-react-app` はどのプラットフォームでも `.env` を勝手に吸い込むようなので、それに任せました。