### PR TITLE
Changed bottom padding on single page for shop

### DIFF
--- a/src/App/Shop.scss
+++ b/src/App/Shop.scss
@@ -15,7 +15,7 @@
   {
     height: 100%;
     box-sizing: border-box;
-    padding: 16px;
+    padding: 16px 16px 64px;
     overflow: scroll;
   }
 


### PR DESCRIPTION
When shop introduce text (lots of words) was set on data, we can't see 'お店までの道順' where behind footer navigation.

So added bottom padding for container on single shop page.